### PR TITLE
Fix usage example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can then compile applications like this (adapt to your desired target archit
 [Hermit kernel]: https://github.com/hermit-os/kernel
 
 ```bash
-docker run --rm -v .:/mnt -w /mnt ghcr.io/hermit-os/hermit-gcc:x86_64 x86_64-hermit-gcc -o app app.c libhermit.a
+docker run --rm -v .:/mnt -w /mnt ghcr.io/hermit-os/hermit-gcc:x86_64 x86_64-hermit-gcc -o app app.c -Wl,--whole-archive libhermit.a -fPIE -pie
 ```
 
 You can also use the image interactively:


### PR DESCRIPTION
The current usage example does not seem to work with even a very simple hello-world C file:

```
ld: strtod.c:(.text+0x1d05): undefined reference to `nanf'
```

The fix seems to be indicating that the libhermit.a file is a whole-archive with a LD argument.

In addition, the produced executable is not bootable if `-fPIE -pie` is not added.